### PR TITLE
正誤情報を技術評論社のサポートページへリンクするようにした

### DIFF
--- a/index.html
+++ b/index.html
@@ -726,14 +726,8 @@
 <p class="impression">Pull Request がんばります</p>
 <p class="impression">Pull Request こんにちは</p>
 
-<h3>誤植など</h3>
-<p>pp159</p>
-<p>誤<code>git clone git@github.com/ユーザ名/hello-world.git</code>
-<p>正<code>git clone git@github.com/ユーザ名/Hello-World.git</code>
-
-<p>pp196</p>
-<p>誤<code>前提すべき</code>
-<p>正<code>前提とすべき</code>
+<h3>正誤情報など</h3>
+<p>技術評論社Webサイト内の<a href="http://gihyo.jp/book/2014/978-4-7741-6366-6/support">本書のサポートページ</a>に掲載しています。</p>
 
 <h3>問い合わせ</h3>
 <p>本サイトについて問い合わせがありましたら<a href="http://hiroki.jp/contact/">こちら</a>からご連絡ください。</p>


### PR DESCRIPTION
@hirocaster さん

本書の編集を担当させていただきました。

正誤情報をサポートページに一本化したほうがわかりやすいのではと感じてPRしました。確認よろしくおねがいします。
