### PR TITLE
Add my impression, and comment workaround.

### DIFF
--- a/index.html
+++ b/index.html
@@ -1167,6 +1167,7 @@ Pull Request初体験です！まるで一つのコミュニティのように�
 <p class="impression">GITHUBがんばるぞ</p>
 <p class="impression">GitHubたのしい</p>
 <p class="impression">2019/08/17 Pull Request</p>
+<p class="impression">安心して練習できるのでありがたいです。</p>
 <p >↑最新のコメント</p>
 <h3>正誤情報など</h3>
 <p>技術評論社Webサイト内の<a href="http://gihyo.jp/book/2014/978-4-7741-6366-6/support">本書のサポートページ</a>に掲載しています。</p>


### PR DESCRIPTION
本の手順通りでは途中で失敗するため、その解消に試行錯誤した結果をここに共有しておきます。

本家プロジェクトには2019年現在、master相当であるgh-pagesブランチ以外に、workをはじめとする他の複数のブランチが増えており、これらが邪魔しているようです。（git pushの際に、localとremoteのworkブランチの競合で叱られ、merge conflict解消で頑張らないといけないようです）

対処は、本家からforkして出来た「自身のfirst-prプロジェクト」にてbranchタブをクリックし、それらの不要なブランチを削除することでした。（同操作を行っても本家プロジェクト側の同ブランチは消えないので安心してください）

その後、改めてgit cloneのところからやり直せば、手順通りで上手くいきました。
ご参考までに。
